### PR TITLE
feat: Added backend logic to split users into groups

### DIFF
--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -56,6 +56,99 @@ async function getAllUsers(req: NextApiRequest, res: NextApiResponse) {
 
 /**
  *
+ * Function to groups users together into groups based on teammate information. If you understand how this function works, you're a genius :D
+ *
+ * @param userList List of user infos
+ * @return list of groups, each represented as `Registration[]`
+ *
+ */
+function generateGroupsFromUserData(userList: Registration[]): Registration[][] {
+  const groupLeader = new Map<string, string>();
+  const groupSize = new Map<string, number>();
+
+  userList.forEach((user) => {
+    groupLeader.set(user.user.preferredEmail, user.user.preferredEmail);
+    groupSize.set(user.user.preferredEmail, 1);
+  });
+
+  const findLeader = (userEmail: string) => {
+    if (groupLeader.get(userEmail) === userEmail) return userEmail;
+    groupLeader.set(userEmail, findLeader(groupLeader.get(userEmail)));
+    return groupLeader.get(userEmail);
+  };
+
+  const validateEmail = (email: string) => {
+    return String(email)
+      .toLowerCase()
+      .match(
+        /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|.(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+      );
+  };
+
+  const mergeGroup = (firstUserEmail: string, secondUserEmail: string) => {
+    const firstUserLeaderEmail = findLeader(firstUserEmail);
+    const secondUserLeaderEmail = findLeader(secondUserEmail);
+    if (firstUserLeaderEmail === secondUserLeaderEmail) return;
+    const firstGroupSize = groupSize.get(firstUserLeaderEmail);
+    const secondGroupSize = groupSize.get(secondUserLeaderEmail);
+    if (firstGroupSize > secondGroupSize) {
+      groupLeader.set(secondUserLeaderEmail, firstUserLeaderEmail);
+      groupSize.set(firstUserLeaderEmail, firstGroupSize + secondGroupSize);
+    } else {
+      groupLeader.set(firstUserLeaderEmail, secondUserLeaderEmail);
+      groupSize.set(secondUserLeaderEmail, firstGroupSize + secondGroupSize);
+    }
+  };
+
+  userList.forEach((user) => {
+    [user.teammate1, user.teammate2, user.teammate3]
+      .filter((email) => validateEmail(email) && groupLeader.has(email))
+      .forEach((teammateEmail) => {
+        mergeGroup(user.user.preferredEmail, teammateEmail);
+      });
+  });
+
+  const preliminaryGroups = new Map<string, Registration[]>();
+  userList
+    .filter((user) => findLeader(user.user.preferredEmail) === user.user.preferredEmail)
+    .forEach((user) => {
+      preliminaryGroups.set(user.user.preferredEmail, []);
+    });
+  userList.forEach((user) => {
+    preliminaryGroups.get(findLeader(user.user.preferredEmail)).push(user);
+  });
+  const validGroup = (potentialGroup: Registration[]) => {
+    if (potentialGroup.length !== 4) return false;
+    const voteCounter = new Map<string, number>();
+    potentialGroup.forEach((user) => {
+      voteCounter.set(user.user.preferredEmail, 0);
+    });
+    potentialGroup.forEach((user) => {
+      [user.teammate1, user.teammate2, user.teammate3]
+        .filter((teammateEmail) => voteCounter.has(teammateEmail))
+        .forEach((teammateEmail) =>
+          voteCounter.set(teammateEmail, voteCounter.get(teammateEmail) + 1),
+        );
+    });
+    let isValidGroup = true;
+    voteCounter.forEach((value, _) => {
+      if (value !== 3) isValidGroup = false;
+    });
+    return isValidGroup;
+  };
+  const ret: Registration[][] = [];
+  preliminaryGroups.forEach((value, _) => {
+    if (validGroup(value)) {
+      ret.push(value);
+    } else {
+      value.forEach((user) => ret.push([user]));
+    }
+  });
+  return ret;
+}
+
+/**
+ *
  * API endpoint to fetch all users from the database
  *
  * @param req HTTP request object


### PR DESCRIPTION
Resolves #78 

## **Overview**
This PR introduces the function to split users into groups for application evaluation purpose. At the high level, the algorithm works as follow: 
- The algorithm assumes an undirected graph in which each vertex is an application and edges are denoted based on teammate email information that users provided during registration. 
- "Teams" will be constructed using [Disjoint-set Union data structure](https://en.wikipedia.org/wiki/Disjoint-set_data_structure). 
- As the last step, the algorithm will run an additional validation logic to filter out invalid groups. If a group is invalid, then all users in that group will be treated as groups of 1 user. A group is valid if the following conditions hold: 
    - Group size is exactly 4. 
    - Each person in the group receives "vouch" from every other people in the group. 
 
## **Notes**
- Function introduced in this PR is not used yet because frontend requires information regarding application scores to be able to render correctly.  